### PR TITLE
Added darknet to requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ argparse
 numpy
 scipy
 matplotlib
+darknet


### PR DESCRIPTION
The darknet module is missing in the requirements which prevents users from testing the code.